### PR TITLE
adding initial version of storm topology to check interface stats error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ kilda-bins/
 tar/
 *.retry
 services/src/api/target/
+**/.checkstyle
+

--- a/services/wfm/pom.xml
+++ b/services/wfm/pom.xml
@@ -31,6 +31,8 @@
         <lombok.version>1.16.20</lombok.version>
         <aspectj.version>1.8.13</aspectj.version>
         <commons.collection.version>4.1</commons.collection.version>
+        <hibernate-validator.version>6.0.10.Final</hibernate-validator.version>
+        <glassfish-el.version>3.0.1-b09</glassfish-el.version>
 
         <aspectj-maven-plugin.version>1.11</aspectj-maven-plugin.version>
         <maven-checkstyle-plugin.version>3.0.0</maven-checkstyle-plugin.version>
@@ -275,6 +277,13 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.hamcrest</groupId>
+            <artifactId>hamcrest-library</artifactId>
+            <version>1.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>${lombok.version}</version>
@@ -301,6 +310,16 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-math3</artifactId>
             <version>3.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <version>${hibernate-validator.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>javax.el</artifactId>
+            <version>${glassfish-el.version}</version>
         </dependency>
     </dependencies>
 
@@ -337,6 +356,44 @@
                         <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     </configuration>
                 </plugin>
+               <plugin>
+                <groupId>org.eclipse.m2e</groupId>
+                <artifactId>lifecycle-mapping</artifactId>
+                <version>1.0.0</version>
+                <configuration>
+                    <lifecycleMappingMetadata>
+                        <pluginExecutions>
+                            <pluginExecution>
+                                <pluginExecutionFilter>
+                                    <groupId>org.codehaus.mojo</groupId>
+                                    <artifactId>aspectj-maven-plugin</artifactId>
+                                    <versionRange>[1.0,)</versionRange>
+                                    <goals>
+                                        <goal>test-compile</goal>
+                                        <goal>compile</goal>
+                                    </goals>
+                                </pluginExecutionFilter>
+                                <action>
+                                    <execute />
+                                </action>
+                            </pluginExecution>
+                            <pluginExecution>
+                                <pluginExecutionFilter>
+                                    <groupId>org.codehaus.mojo</groupId>
+                                    <artifactId>tidy-maven-plugin</artifactId>
+                                    <versionRange>[1.1.0,)</versionRange>
+                                    <goals>
+                                        <goal>check</goal>
+                                    </goals>
+                                </pluginExecutionFilter>
+                                <action>
+                                    <execute />
+                                </action>
+                            </pluginExecution>
+                        </pluginExecutions>
+                    </lifecycleMappingMetadata>
+                </configuration>
+            </plugin>
             </plugins>
         </pluginManagement>
         <plugins>

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/InterfaceMonTopology.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/InterfaceMonTopology.java
@@ -1,0 +1,82 @@
+package org.openkilda.wfm.topology.ifmon;
+
+import java.util.List;
+
+import org.apache.storm.generated.StormTopology;
+import org.apache.storm.topology.TopologyBuilder;
+import org.openkilda.wfm.LaunchEnvironment;
+import org.openkilda.wfm.error.NameCollisionException;
+import org.openkilda.wfm.topology.AbstractTopology;
+import org.openkilda.wfm.topology.ifmon.InterfaceMonTopologyConfig.InterfaceMonConfig;
+import org.openkilda.wfm.topology.ifmon.bolts.InterfaceMetricAlerterBolt;
+import org.openkilda.wfm.topology.ifmon.bolts.InterfaceMetricFilterBolt;
+import org.openkilda.wfm.topology.ifmon.bolts.InterfaceMetricMonitorBolt;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class InterfaceMonTopology extends AbstractTopology<InterfaceMonTopologyConfig> {
+
+	private final static Logger logger = LoggerFactory.getLogger(InterfaceMonTopology.class);
+	private final static String INTERFACE_MON_TSDB_SPOUT_ID = "ifmon-spout";
+	private final static String INTERFACE_MON_FILTER_BOLT = "ifmon-filter-bolt";
+	private final static String INTERFACE_MON_MONITOR_BOLT = "ifmon-monitor-bolt";
+	private final static String INTERFACE_MON_ALERTER_BOLT = "ifmon-alerter-bolt";
+
+	public InterfaceMonTopology(LaunchEnvironment env) {
+		super(env, InterfaceMonTopologyConfig.class);
+	}
+
+	@Override
+	public StormTopology createTopology() throws NameCollisionException {
+		logger.info("Create InterfaceMonTopology - {}", topologyName);
+
+		InterfaceMonConfig config = topologyConfig.getInterfaceMonConfig();
+
+		String kafkaOtsdbTopic = topologyConfig.getKafkaOtsdbTopic();
+		checkAndCreateTopic(kafkaOtsdbTopic);
+
+		logger.debug("connecting to {} topic", kafkaOtsdbTopic);
+		TopologyBuilder builder = new TopologyBuilder();
+		builder.setSpout(INTERFACE_MON_TSDB_SPOUT_ID, createKafkaSpout(kafkaOtsdbTopic, INTERFACE_MON_TSDB_SPOUT_ID),
+				config.getNumSpouts());
+
+		// filter tuples based on the metric we are interested in
+		List<String> metrics = config.getInterfaceMetrics();
+		InterfaceMetricFilterBolt filterBolt = new InterfaceMetricFilterBolt(metrics);
+		builder.setBolt(INTERFACE_MON_FILTER_BOLT, filterBolt, config.getNumFilterBoltExecutors())
+				.shuffleGrouping(INTERFACE_MON_TSDB_SPOUT_ID);
+
+		// Any interface metric signaling trouble?
+		InterfaceMetricMonitorBolt monitorBolt = new InterfaceMetricMonitorBolt(metrics,
+				config.getMonitorBoltCacheTimeout(), config.getMonitorBoltWindowsize());
+		builder.setBolt(INTERFACE_MON_MONITOR_BOLT, monitorBolt, config.getNumMonitorBoltExecutors())
+				.shuffleGrouping(INTERFACE_MON_FILTER_BOLT);
+
+		// Potential problematic interface metrics will trigger alert to both Kabana and
+		// Alertera
+		InterfaceMetricAlerterBolt alerterBolt = new InterfaceMetricAlerterBolt(config.getTpnEndpoint(),
+				config.getTpnUsername(), config.getTpnPassword());
+		builder.setBolt(INTERFACE_MON_ALERTER_BOLT, alerterBolt, config.getNumAltererBoltExecutors())
+				.shuffleGrouping(INTERFACE_MON_MONITOR_BOLT);
+
+		// createHealthCheckHandler(builder, ServiceType.PACKETMON_TOPOLOGY.getId());
+
+		return builder.createTopology();
+	}
+
+	/**
+	 * Main run loop.
+	 *
+	 * @param args
+	 *            Command line arguments
+	 */
+	public static void main(String[] args) {
+		try {
+			LaunchEnvironment env = new LaunchEnvironment(args);
+			(new InterfaceMonTopology(env)).setup();
+		} catch (Exception e) {
+			System.exit(handleLaunchException(e));
+		}
+	}
+
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/InterfaceMonTopologyConfig.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/InterfaceMonTopologyConfig.java
@@ -1,0 +1,79 @@
+package org.openkilda.wfm.topology.ifmon;
+
+import java.util.List;
+
+import org.openkilda.wfm.topology.AbstractTopologyConfig;
+
+import com.sabre.oss.conf4j.annotation.Configuration;
+import com.sabre.oss.conf4j.annotation.Default;
+import com.sabre.oss.conf4j.annotation.IgnoreKey;
+import com.sabre.oss.conf4j.annotation.Key;
+
+public interface InterfaceMonTopologyConfig extends AbstractTopologyConfig {
+	
+	@IgnoreKey
+	InterfaceMonConfig getInterfaceMonConfig();
+	
+    default String getKafkaOtsdbTopic() {
+        return getKafkaTopics().getOtsdbTopic();
+    }
+    
+    @Configuration
+    @Key("interfacemon")
+    interface InterfaceMonConfig {
+
+        @Key("num.spouts")
+        @Default("1")
+        int getNumSpouts();
+        
+        @Key("filterbolt.executors")
+        @Default("1")
+        int getNumFilterBoltExecutors();
+        
+        @Key("filterbolt.tasks")
+        @Default("1")
+        int getNumFilterBoltTasks();        
+
+        @Key("monitorbolt.executors")
+        @Default("1")
+        int getNumMonitorBoltExecutors();
+
+        @Key("monitorbolt.tasks")
+        @Default("1")
+        int getNumMonitorBoltTasks();
+
+        @Key("monitorbolt.windowsize")
+        @Default("60")
+        int getMonitorBoltWindowsize();
+        
+        @Key("monitorbolt.cachetimeout.seconds")
+        @Default("900")
+        int getMonitorBoltCacheTimeout();
+
+        @Key("alerterbolt.executors")
+        @Default("1")
+        int getNumAltererBoltExecutors();
+
+        @Key("alerterbolt.tasks")
+        @Default("1")
+        int getNumAlerterBoltTasks();
+
+    	@Key("metrics")
+    	@Default("[pen.switch.rx-errors,pen.switch.tx-errors," +
+    			  "pen.switch.rx-dropped,pen.switch.tx-dropped," + 
+    			  "pen.switch.rx-crc-error,pen.switch.collisions," +
+    			  "pen.switch.rx-frame-error,pen.switch.rx-over-error]")
+    	List<String> getInterfaceMetrics();
+    	
+    	@Key("tpn.endpoint")
+    	String getTpnEndpoint();
+    	
+    	@Key("tpn.username")
+    	String getTpnUsername();
+    	
+    	@Key("tpn.password")
+    	String getTpnPassword();
+
+    }    	
+ 
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/bolts/InterfaceMetricAlerterBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/bolts/InterfaceMetricAlerterBolt.java
@@ -1,0 +1,75 @@
+package org.openkilda.wfm.topology.ifmon.bolts;
+
+import static org.openkilda.messaging.Utils.MAPPER;
+import static org.openkilda.wfm.topology.ifmon.data.InterfaceMetricConst.TAG_PORT;
+import static org.openkilda.wfm.topology.ifmon.data.InterfaceMetricConst.TAG_SWITCHID;
+
+import java.util.Map;
+
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.base.BaseRichBolt;
+import org.apache.storm.tuple.Tuple;
+import org.openkilda.messaging.info.Datapoint;
+import org.openkilda.wfm.topology.ifmon.utils.MicroServiceClient;
+import org.openkilda.wfm.topology.ifmon.utils.Utils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/*
+ * tuples received by this bolt signaling potential errors. This bold will try to trigger alerts with proper information
+ */
+public class InterfaceMetricAlerterBolt extends BaseRichBolt {
+
+	private String tpnEndpoint;
+	private String tpnUserName;
+	private String tpnPassword;
+	
+	private OutputCollector collector;
+	private MicroServiceClient msClient;
+	
+	private static Logger logger = LoggerFactory.getLogger(InterfaceMetricAlerterBolt.class);
+	
+	public InterfaceMetricAlerterBolt(String tpnEndpoint, String tpnUser, String tpnPassword) {
+		this.tpnEndpoint = tpnEndpoint;
+		this.tpnUserName = tpnUser;
+		this.tpnPassword = tpnPassword;
+	}
+	
+	@Override
+	public void prepare(Map stormConf, TopologyContext context, OutputCollector collector) {
+		this.collector = collector;
+		msClient = new MicroServiceClient(tpnEndpoint, tpnUserName, tpnPassword);
+		
+	}
+
+	@Override
+	public void execute(Tuple tuple) {
+		
+		final String data = tuple.getString(0);
+		
+		try {
+			Datapoint datapoint = MAPPER.readValue(data, Datapoint.class);
+			String metric = datapoint.getMetric();
+			String switchId = datapoint.getTags().get(TAG_SWITCHID);
+			String port = datapoint.getTags().get(TAG_PORT);
+			
+			String legacyDpid = Utils.dpidKildaToLegacy(switchId);
+			String switchName = msClient.resolveSwitch(legacyDpid).getCommonName();
+			
+			logger.error("Switch {} port {} metric {} found monotonically increasing", switchName, port, metric);
+			
+		} catch(Exception e) {
+			logger.error("Failed reading data:" + data, e);
+		} finally {
+			collector.ack(tuple);
+		}
+	}
+
+	@Override
+	public void declareOutputFields(OutputFieldsDeclarer declarer) {
+
+	}
+
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/bolts/InterfaceMetricFilterBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/bolts/InterfaceMetricFilterBolt.java
@@ -1,0 +1,71 @@
+package org.openkilda.wfm.topology.ifmon.bolts;
+
+import static org.openkilda.messaging.Utils.MAPPER;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.base.BaseRichBolt;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Tuple;
+import org.openkilda.messaging.info.Datapoint;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/*
+ * filters data points with specific metric name
+ * pen.switch.rx-crc-error
+ * pen.switch.collisions
+ * pen.switch.rx-over-error
+ * pen.switch.rx-dropped
+ * pen.switch.tx-dropped
+ * pen.switch.rx-errors
+ * pen.switch.tx-errors
+ * pen.switch.rx-frame-error
+ */
+
+
+public class InterfaceMetricFilterBolt extends BaseRichBolt {
+
+	private final static Logger logger = LoggerFactory.getLogger(InterfaceMetricFilterBolt.class);
+	private final List<String> metrics;
+	private OutputCollector collector;
+
+	public InterfaceMetricFilterBolt(List<String> metrics) {
+
+		this.metrics = metrics;
+	}
+
+	@Override
+	public void prepare(Map stormConf, TopologyContext context, OutputCollector collector) {
+		this.collector = collector;
+	}
+
+	@Override
+	public void execute(Tuple tuple) {
+		final String data = tuple.getString(0);
+		try {
+			Datapoint datapoint = MAPPER.readValue(data, Datapoint.class);
+
+			// the tuple is not anchored, not affecting how spouts ack it.
+			if (metrics.contains(datapoint.getMetric())) {
+				collector.emit(Arrays.asList(tuple));
+			}
+		} catch (Exception e) {
+			logger.error("Failed reading data:" + data, e);
+		} finally {
+			collector.ack(tuple);
+		}
+
+	}
+
+	@Override
+	public void declareOutputFields(OutputFieldsDeclarer declarer) {
+		declarer.declare(new Fields("datapoint"));
+	}
+
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/bolts/InterfaceMetricMonitorBolt.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/bolts/InterfaceMetricMonitorBolt.java
@@ -1,0 +1,106 @@
+package org.openkilda.wfm.topology.ifmon.bolts;
+
+import static org.openkilda.messaging.Utils.MAPPER;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+
+/*
+ * Check if a particular metric on switch:port signifying an error condition
+ * The condition is for a certain window size, the values are increasing.
+ */
+
+import org.apache.storm.task.OutputCollector;
+import org.apache.storm.task.TopologyContext;
+import org.apache.storm.topology.OutputFieldsDeclarer;
+import org.apache.storm.topology.base.BaseRichBolt;
+import org.apache.storm.tuple.Fields;
+import org.apache.storm.tuple.Tuple;
+import org.apache.storm.tuple.Values;
+import org.openkilda.messaging.info.Datapoint;
+import org.openkilda.wfm.topology.ifmon.data.InterfaceMetricStats;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+
+import static org.openkilda.wfm.topology.ifmon.data.InterfaceMetricConst.*;
+
+
+public class InterfaceMetricMonitorBolt extends BaseRichBolt {
+	
+	private final List<String> metrics;
+	private final int cacheTimeoutSeconds;
+	private final int windowSize;
+	
+	private Map<String, LoadingCache<String, InterfaceMetricStats>> cache;
+	private OutputCollector collector;
+	
+	private static Logger logger = LoggerFactory.getLogger(InterfaceMetricMonitorBolt.class);
+	
+	public InterfaceMetricMonitorBolt(List<String> metrics, int cacheTimeoutSeconds, int windowSize) {
+		this.metrics = metrics;
+		this.cacheTimeoutSeconds = cacheTimeoutSeconds;
+		this.windowSize = windowSize;
+	}
+
+	@Override
+	public void prepare(Map stormConf, TopologyContext context, OutputCollector collector) {
+		this.collector = collector;
+		
+		// construct the cache holding interface metrics, which will be used to determine
+		// if it signals potential problems
+		for (String metric: metrics) {
+			LoadingCache<String, InterfaceMetricStats> metricCache = 
+					CacheBuilder.newBuilder()
+					.expireAfterAccess(cacheTimeoutSeconds, TimeUnit.SECONDS)
+					.build(new CacheLoader<String, InterfaceMetricStats> () {
+						@Override
+						public InterfaceMetricStats load(String s) {
+							return new InterfaceMetricStats(windowSize);
+						}
+					});
+			
+			cache.put(metric, metricCache);		
+		}
+		
+	}
+
+	@Override
+	public void execute(Tuple tuple) {
+		final String data = tuple.getString(0);
+		
+		try {
+			Datapoint datapoint =  MAPPER.readValue(data, Datapoint.class);
+			String metric = datapoint.getMetric();
+			String switchId = datapoint.getTags().get(TAG_SWITCHID);
+			String port = datapoint.getTags().get(TAG_PORT);
+			InterfaceMetricStats ifStats = cache.get(metric).get(String.format("%s_%s", switchId, port));
+			
+			ifStats.add(datapoint.getTimestamp(), datapoint.getValue().doubleValue());
+			if (ifStats.isValueMonotonicallyIncreasing()) {
+				// here we clear the the stats to avoid the situation, where if the interface is problematic,
+				// each incoming metric will trigger an alert. This is an area need more tweaking
+				ifStats.reset();
+				collector.emit(Arrays.asList(tuple));
+			}
+			
+		} catch(Exception e) {
+			logger.error("Failed reading data:" + data, e);
+		} finally {
+			collector.ack(tuple);
+		}
+
+	}
+
+	@Override
+	public void declareOutputFields(OutputFieldsDeclarer declarer) {
+		declarer.declare(new Fields("datapoint"));
+
+	}
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/data/InterfaceMetricConst.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/data/InterfaceMetricConst.java
@@ -1,0 +1,6 @@
+package org.openkilda.wfm.topology.ifmon.data;
+
+public interface InterfaceMetricConst {
+	public static String TAG_SWITCHID = "switchid";
+	public static String TAG_PORT = "port";
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/data/InterfaceMetricStats.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/data/InterfaceMetricStats.java
@@ -1,0 +1,53 @@
+package org.openkilda.wfm.topology.ifmon.data;
+
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+
+public class InterfaceMetricStats {
+	
+	private DescriptiveStatistics dataValues;
+	
+	private int windowSize;
+	private long lastTimeValue;
+
+	
+	public InterfaceMetricStats(int windowSize) {
+		this.windowSize = windowSize;
+		this.dataValues = new DescriptiveStatistics(windowSize);
+	}
+	
+	
+	public void add(long time, double value) {
+		// past experience shows the datapoint may be out of order with regard to time, and might be duplicated
+		// likely for every possible switch_port, the metric comes at regular intervals, like every 10s
+		if (time > lastTimeValue ) {
+			lastTimeValue = time;
+			dataValues.addValue(value);
+		}
+	}
+	
+	/**
+	 * Check if values are monotonically increasing: 
+	 * each value is greater than or equal to previous one, and the last value is greater than the first one
+	 * @return true if later datapoint is greater than previous ones, else false.
+	 */
+	public boolean isValueMonotonicallyIncreasing() {
+		double[] values = dataValues.getValues();
+		
+		if (values.length < windowSize) {
+			return false;
+		}
+		
+		for (int i = 1; i < values.length; i++ ) {
+			if ( values[i] < values[i - 1 ]) {
+				return false;
+			}
+		}
+		return values[values.length - 1] > values[0];
+		
+	}
+
+
+	public void reset() {
+		dataValues.clear();
+	}
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/utils/GetTokenResponsePayload.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/utils/GetTokenResponsePayload.java
@@ -1,0 +1,89 @@
+package org.openkilda.wfm.topology.ifmon.utils;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonSerialize
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder(value = { "scope", "token_type", "expires_in", "refresh_token", "access_token" })
+public class GetTokenResponsePayload {
+
+	@JsonProperty("scope")
+	private String scope;
+
+	@JsonProperty("token_type")
+	private String tokenType;
+
+	@JsonProperty("expires_in")
+	private int expiresIn;
+
+	@JsonProperty("refresh_token")
+	private String refreshToken;
+
+	@JsonProperty("access_token")
+	private String accessToken;
+
+	@JsonCreator
+	public GetTokenResponsePayload(@JsonProperty("scope") final String scope,
+			@JsonProperty("token_type") final String tokenType, @JsonProperty("expires_in") int expiresIn,
+			@JsonProperty("refresh_token") final String refreshToken,
+			@JsonProperty("access_token") String accessToken) {
+		this.scope = scope;
+		this.tokenType = tokenType;
+		this.expiresIn = expiresIn;
+		this.refreshToken = refreshToken;
+		this.accessToken = accessToken;
+	}
+
+	public String getScope() {
+		return scope;
+	}
+
+	public void setScope(String scope) {
+		this.scope = scope;
+	}
+
+	public String getTokenType() {
+		return tokenType;
+	}
+
+	public void setTokenType(String tokenType) {
+		this.tokenType = tokenType;
+	}
+
+	public int getExpiresIn() {
+		return expiresIn;
+	}
+
+	public void setExpiresIn(int expiresIn) {
+		this.expiresIn = expiresIn;
+	}
+
+	public String getRefreshToken() {
+		return refreshToken;
+	}
+
+	public void setRefreshToken(String refreshToken) {
+		this.refreshToken = refreshToken;
+	}
+
+	public String getAccessToken() {
+		return accessToken;
+	}
+
+	public void setAccessToken(String accessToken) {
+		this.accessToken = accessToken;
+	}
+
+	@Override
+	public String toString() {
+		return toStringHelper(this).add("scope", scope).add("token_type", tokenType).add("expires_in", expiresIn)
+				.add("refresh_token", refreshToken).add("access_token", accessToken).toString();
+	}
+
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/utils/MicroServiceClient.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/utils/MicroServiceClient.java
@@ -1,0 +1,220 @@
+package org.openkilda.wfm.topology.ifmon.utils;
+
+import java.io.IOException;
+import java.security.KeyManagementException;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.SSLContext;
+
+import org.apache.http.HttpStatus;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.conn.ssl.NoopHostnameVerifier;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.http.util.EntityUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.net.HttpHeaders;
+
+public class MicroServiceClient {
+
+	private final String tpnUsername;
+	private final String tpnPassword;
+	private long tokenExirationTime = 0;
+	private String accessToken = null;
+
+	private final String tpnEndpoint;
+	private CloseableHttpClient httpClient;
+
+	private ObjectMapper mapper = new ObjectMapper();
+	private Map<String, PisSwitch> switchMapping = new HashMap<>();
+
+	private static Logger logger = LoggerFactory.getLogger(MicroServiceClient.class);
+
+	public MicroServiceClient(String tpnEndpoint, String tpnUsername, String tpnPassword) {
+		this.tpnUsername = tpnUsername;
+		this.tpnPassword = tpnPassword;
+		this.tpnEndpoint = tpnEndpoint;
+
+		try {
+			SSLContext sslContext = new SSLContextBuilder().loadTrustMaterial(null, (certificate, authType) -> true)
+					.build();
+
+			httpClient = HttpClients.custom()
+					.setDefaultHeaders(Arrays.asList(new BasicHeader(HttpHeaders.ACCEPT, "Application/json")))
+					.setSSLContext(sslContext).setSSLHostnameVerifier(new NoopHostnameVerifier()).build();
+		} catch (KeyManagementException | NoSuchAlgorithmException | KeyStoreException e) {
+			logger.error("Failed to create micro service client", e);
+		}
+
+		logger.info("Successfully created micro service client");
+	}
+
+	public void getAuthToken() throws MicroServiceException {
+
+		String getTokenUri = String.format("https://%s/1.0.0/auth/generatetoken", tpnEndpoint);
+		HttpPost getTokenPost = new HttpPost(getTokenUri);
+
+		List<NameValuePair> params = new ArrayList<>();
+		params.add(new BasicNameValuePair("grant_type", "password"));
+		params.add(new BasicNameValuePair("username", tpnUsername));
+		params.add(new BasicNameValuePair("password", tpnPassword));
+
+		CloseableHttpResponse response = null;
+
+		try {
+			getTokenPost.setEntity(new UrlEncodedFormEntity(params));
+			response = httpClient.execute(getTokenPost);
+
+			String getTokenPayload = EntityUtils.toString(response.getEntity());
+			if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+				logger.error("Failed to get access token for user {} for reason {}", tpnUsername, getTokenPayload);
+				throw new MicroServiceException("Failed to get acess token for user " + tpnUsername);
+			}
+
+			GetTokenResponsePayload payload = mapper.readValue(getTokenPayload, GetTokenResponsePayload.class);
+			accessToken = payload.getAccessToken();
+			tokenExirationTime = System.currentTimeMillis() + payload.getExpiresIn() * 1000;
+
+			logger.info("Successfully retrieved access token for micro services");
+		} catch (IOException e) {
+			throw new MicroServiceException(e);
+		} finally {
+			if (response != null) {
+				try {
+					response.close();
+				} catch (IOException e) {
+
+				}
+			}
+		}
+	}
+
+	public Map<String, PisSwitch> getDpidSwitchMapping() throws MicroServiceException {
+
+		Map<String, PisSwitch> switchMapping = new HashMap<>();
+		String getSwitchUri = String.format("https://%s//pis/1.0.0/switch", tpnEndpoint);
+
+		CloseableHttpResponse response = null;
+
+		try {
+			refreshAccessTokenIfNeeded();
+
+			HttpGet getSwitchMethod = new HttpGet(getSwitchUri);
+			getSwitchMethod.addHeader(HttpHeaders.AUTHORIZATION, String.format("Bearer %s", accessToken));
+			response = httpClient.execute(getSwitchMethod);
+
+			String responsePaylod = EntityUtils.toString(response.getEntity());
+			if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+				logger.error("Failed to get switch information from pis with reason", responsePaylod);
+				throw new MicroServiceException("Failed to get switch information from pis");
+			}
+
+			PisGetSwitchResponsePayload payload = mapper.readValue(responsePaylod, PisGetSwitchResponsePayload.class);
+			payload.getSwitches().stream().forEach(sw -> switchMapping.put(sw.getDpid(), sw));
+
+			logger.debug("Got switch dpid/switch mapping:\n{}", responsePaylod);
+
+		} catch (IOException e) {
+			throw new MicroServiceException(e);
+		} finally {
+			if (response != null) {
+				try {
+					response.close();
+				} catch (IOException e) {
+
+				}
+			}
+		}
+
+		return switchMapping;
+	}
+
+	public PisSwitch resolveSwitch(String switchDpid) throws MicroServiceException {
+		PisSwitch sw = switchMapping.get(switchDpid);
+
+		if (sw == null) {
+			Map<String, PisSwitch> newMapping = getDpidSwitchMapping();
+			// don't prematurely clear/reset the switch mapping, it might be just one
+			// switch problem while the rest can still provide useful infomration
+			switchMapping = newMapping;
+			sw = switchMapping.get(switchDpid);
+		}
+
+		if (sw == null) {
+			logger.error("Cannot find switch with dpid {} in lis", switchDpid);
+			throw new MicroServiceException(String.format("Cannot find switch with dpid %s in lis", switchDpid));
+		}
+
+		return sw;
+	}
+
+	public PisSwitchPortResponsePayload getSwitchPortDetail(String switchDpid, int switchPort)
+			throws MicroServiceException {
+
+		CloseableHttpResponse response = null;
+		PisSwitchPortResponsePayload payload = null;
+		try {
+			refreshAccessTokenIfNeeded();
+
+			PisSwitch localSwitch = resolveSwitch(switchDpid);
+			String localUuid = localSwitch.getUuid();
+
+			String getSwitchPortDetailUrl = String.format("https://%s/pis/1.0.0/switchuuid/%s/port/%s", tpnEndpoint,
+					localUuid, Integer.toString(switchPort));
+
+			HttpGet getSwitchMethod = new HttpGet(getSwitchPortDetailUrl);
+			getSwitchMethod.addHeader(HttpHeaders.AUTHORIZATION, String.format("Bearer %s", accessToken));
+			response = httpClient.execute(getSwitchMethod);
+
+			String responsePaylod = EntityUtils.toString(response.getEntity());
+			if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) {
+				String errMsg = String.format("Failed to get switch/port information from pis for %s(%s):%d",
+						switchDpid, localUuid, switchPort);
+				logger.debug(errMsg + "\n{}", responsePaylod);
+				throw new MicroServiceException(errMsg);
+			}
+
+			payload = mapper.readValue(responsePaylod, PisSwitchPortResponsePayload.class);
+
+			logger.debug("Successfully got {}:{} details:\n{}", switchDpid, switchPort, responsePaylod);
+
+		} catch (IOException e) {
+			throw new MicroServiceException(e);
+		} finally {
+			if (response != null) {
+				try {
+					response.close();
+				} catch (IOException e) {
+
+				}
+			}
+		}
+
+		return payload;
+	}
+
+	private void refreshAccessTokenIfNeeded() throws MicroServiceException {
+		if (tokenExirationTime - System.currentTimeMillis() < TimeUnit.SECONDS.toMillis(10)) {
+			logger.debug("Refreshing access token");
+			getAuthToken();
+		}
+	}
+
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/utils/MicroServiceException.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/utils/MicroServiceException.java
@@ -1,0 +1,16 @@
+package org.openkilda.wfm.topology.ifmon.utils;
+
+public class MicroServiceException extends Exception {
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	public MicroServiceException(String message) {
+		super(message);
+	}
+	
+	public MicroServiceException(Exception e) {
+		super(e);
+	}
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/utils/PisGetSwitchResponsePayload.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/utils/PisGetSwitchResponsePayload.java
@@ -1,0 +1,40 @@
+package org.openkilda.wfm.topology.ifmon.utils;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonSerialize
+@JsonInclude(JsonInclude.Include.NON_NULL)
+
+public class PisGetSwitchResponsePayload {
+
+	@JsonProperty("switches")
+	private List<PisSwitch> switches;
+
+	@JsonCreator
+	public PisGetSwitchResponsePayload(@JsonProperty("switches") final List<PisSwitch> switches) {
+		this.switches = switches;
+	}
+
+	public List<PisSwitch> getSwitches() {
+		return switches;
+	}
+
+	public void setSwitches(List<PisSwitch> switches) {
+		this.switches = switches;
+	}
+
+	@Override
+	public String toString() {
+
+		List<String> allSwitches = switches.stream().map(x -> x.toString()).collect(Collectors.toList());
+
+		return "PisGetSwitchResponsePayload [switches=" + String.join("\n", allSwitches) + "]";
+	}
+
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/utils/PisSwitch.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/utils/PisSwitch.java
@@ -1,0 +1,74 @@
+package org.openkilda.wfm.topology.ifmon.utils;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonSerialize
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder(value = { "popuuid", "dpid", "commonname", "uuid" })
+public class PisSwitch {
+
+	@JsonProperty("popuuid")
+	private String popUuid;
+
+	@JsonProperty("dpid")
+	private String dpid;
+
+	@JsonProperty("commonname")
+	private String commonName;
+
+	@JsonProperty("uuid")
+	private String uuid;
+
+	@JsonCreator
+	public PisSwitch(@JsonProperty("popuuid") final String popUuid, @JsonProperty("dpid") final String dpid,
+			@JsonProperty("commonname") final String commonName, @JsonProperty("uuid") final String uuid) {
+
+		this.popUuid = popUuid;
+		this.dpid = dpid;
+		this.commonName = commonName;
+		this.uuid = uuid;
+	}
+
+	public String getPopUuid() {
+		return popUuid;
+	}
+
+	public void setPopUuid(String popUuid) {
+		this.popUuid = popUuid;
+	}
+
+	public String getDpid() {
+		return dpid;
+	}
+
+	public void setDpid(String dpid) {
+		this.dpid = dpid;
+	}
+
+	public String getCommonName() {
+		return commonName;
+	}
+
+	public void setCommonName(String commonName) {
+		this.commonName = commonName;
+	}
+
+	public String getUuid() {
+		return uuid;
+	}
+
+	public void setUuid(String uuid) {
+		this.uuid = uuid;
+	}
+
+	@Override
+	public String toString() {
+		return "PisSwitch [popUuid=" + popUuid + ", dpid=" + dpid + ", commonName=" + commonName + ", uuid=" + uuid
+				+ "]";
+	}
+
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/utils/PisSwitchPortResponsePayload.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/utils/PisSwitchPortResponsePayload.java
@@ -1,0 +1,98 @@
+package org.openkilda.wfm.topology.ifmon.utils;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+@JsonSerialize
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder(value = { "circuitid", "cablebearerid", "notes"})
+@JsonIgnoreProperties({ "assignmenttype", "interfacetype", "status", "crossconnect", "odfmdf", "mmr",
+		"remoteswitchcode", "remoteport", "provider", "bandwidth", "latency", "farenddescription", "helpdeskphone",
+		"comment", "email", "faulthistory" })
+public class PisSwitchPortResponsePayload {
+
+	@JsonProperty("circuitid")
+	private String circuitId;
+	@JsonProperty("cablebearerid")
+	private String cableBearerId;
+	@JsonProperty("notes")
+	private String notes;
+
+	@JsonCreator
+	public PisSwitchPortResponsePayload(@JsonProperty("circuitid") final String circuitId,
+			@JsonProperty("cablebearerid") String cableBearerId, @JsonProperty("notes") final String notes) {
+
+		this.circuitId = circuitId;
+		this.cableBearerId = cableBearerId;
+		this.notes = notes;
+	}
+
+	public String getCircuitId() {
+		return circuitId;
+	}
+
+	public void setCircuitId(String circuitId) {
+		this.circuitId = circuitId;
+	}
+
+	public String getCableBearerId() {
+		return cableBearerId;
+	}
+
+	public void setCableBearerId(String cableBearerId) {
+		this.cableBearerId = cableBearerId;
+	}
+
+	public String getNotes() {
+		return notes;
+	}
+
+	public void setNotes(String notes) {
+		this.notes = notes;
+	}
+
+	@Override
+	public int hashCode() {
+		final int prime = 31;
+		int result = 1;
+		result = prime * result + ((cableBearerId == null) ? 0 : cableBearerId.hashCode());
+		result = prime * result + ((circuitId == null) ? 0 : circuitId.hashCode());
+		result = prime * result + ((notes == null) ? 0 : notes.hashCode());
+		return result;
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj)
+			return true;
+		if (obj == null)
+			return false;
+		if (getClass() != obj.getClass())
+			return false;
+		PisSwitchPortResponsePayload other = (PisSwitchPortResponsePayload) obj;
+		if (cableBearerId == null) {
+			if (other.cableBearerId != null)
+				return false;
+		} else if (!cableBearerId.equals(other.cableBearerId))
+			return false;
+		if (circuitId == null) {
+			if (other.circuitId != null)
+				return false;
+		} else if (!circuitId.equals(other.circuitId))
+			return false;
+		if (notes == null) {
+			if (other.notes != null)
+				return false;
+		} else if (!notes.equals(other.notes))
+			return false;
+		return true;
+	}
+
+
+	
+	
+}

--- a/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/utils/Utils.java
+++ b/services/wfm/src/main/java/org/openkilda/wfm/topology/ifmon/utils/Utils.java
@@ -1,0 +1,12 @@
+package org.openkilda.wfm.topology.ifmon.utils;
+
+public class Utils {
+	
+	public static String dpidKildaToLegacy(String dpid) {
+		return "SW" + dpid.toUpperCase().replaceAll(":", "");
+	}
+	
+	public static String dpidLegacyToKilda(String dpid) {
+		return dpid.toLowerCase().substring("SW".length()).replaceAll("[0-9a-f]{2}(?!$)", "$0:");
+	}
+}

--- a/services/wfm/src/main/resources/topology.properties
+++ b/services/wfm/src/main/resources/topology.properties
@@ -32,6 +32,26 @@ packetmon.badflowbolt.workers = 5
 packetmon.tsdbbolt.executors = 3
 packetmon.tsdbbolt.workers = 3
 
+
+# following have default values set in configuration class
+# while tpn credentials must be set.
+#interfacemon.num.spouts=1
+#interfacemon.filterbolt.executers=1
+#interfacemon.filterbotl.tasks=1
+#interfacemon.monitorbolt.executers=1
+#interfacemon.monitorbolt.tasks=1
+#interfacemon.monitorbolt.cachetimeout.seconds=900
+#interfacemon.alerterbolt.executers=1
+#interfacemon.alerterbolt.tasks=1
+#interfacemon.metrics=[pen.switch.rx-errors,pen.switch.tx-errors,\
+#                      pen.switch.rx-dropped,pen.switch.tx-dropped,\
+#                      pen.switch.rx-crc-error,pen.switch.collisions,\
+#                      pen.switch.rx-frame-error,pen.switch.rx-over-error]
+interfacemon.tpn.endpoint=penapi.pen.telstra.com
+interfacemon.tpn.username=
+interfacemon.tpn.password=
+
+
 neo4j.hosts = neo4j.pendev:7687
 neo4j.user = neo4j
 neo4j.pswd = temppass


### PR DESCRIPTION
the initial version of interface metric monitoring, only log an error if a metric is found monotonically increasing. Only for you to have a look and suggestions.
Next is to test locally(if possible) and integrate with Jenkins CICD pipeline for staging/production deployment.
Alerta integration will flow when the logging only solution works in staging/production.

The base branch packet_mon cannot compile cleanly. one example is flow.getFlowId not defined. More generally, which branch shall be use as the base for open-kilda development?